### PR TITLE
Remove dependency on laminas/laminas-console

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0]
+        php: [7.4, 8.0]
 
     steps:
     - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.4, 8.0]
+        php: [7.3, 7.4, 8.0]
 
     steps:
     - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "minimum-stability": "RC",
     "require": {
-        "php": "^7.4 || ~8.0.0",
+        "php": "^7.3 || ~8.0.0",
         "codeception/lib-innerbrowser": "^1.0",
         "codeception/codeception": "^4.0",
         "laminas/laminas-db": "^2.11.3",

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,9 @@
     ],
     "minimum-stability": "RC",
     "require": {
-        "php": "^5.6 | ^7.0 | ^8.0",
+        "php": "^7.4 || ~8.0.0",
         "codeception/lib-innerbrowser": "^1.0",
         "codeception/codeception": "^4.0",
-        "laminas/laminas-console": "^2.8.0",
         "laminas/laminas-db": "^2.11.3",
         "laminas/laminas-mvc": "^3.1.1"
     },


### PR DESCRIPTION
References https://github.com/Codeception/module-laminas/issues/12 and removes the dependency on `laminas/laminas-console`. A `class_exists` check is still happening in \Codeception\Module\Laminas line 98, which should preserve functionality for older clients.

A major version is recommended for this PR, as we are dropping support for PHP < 7.3