### PR TITLE
Add public getter to access the application instance

### DIFF
--- a/src/Codeception/Lib/Connector/Laminas.php
+++ b/src/Codeception/Lib/Connector/Laminas.php
@@ -154,6 +154,11 @@ class Laminas extends AbstractBrowser
         $this->persistentFactories[$name] = $factory;
     }
 
+    public function getApplication(): ?ApplicationInterface
+    {
+        return $this->application;
+    }
+
     private function extractHeaders(BrowserKitRequest $browserKitRequest): Headers
     {
         $headers        = [];

--- a/src/Codeception/Module/Laminas.php
+++ b/src/Codeception/Module/Laminas.php
@@ -64,8 +64,6 @@ use function file_exists;
  */
 class Laminas extends Framework implements DoctrineProvider, PartedModule
 {
-    public ApplicationInterface $application;
-
     public AdapterInterface $db;
 
     /** @var LaminasConnector */


### PR DESCRIPTION
Useful case:
* Access ServiceManager from a Helper class with `$this->getModule('Laminas')->client->getApplication()->getServiceManager()`

Closes #10