### PR TITLE
Returned service is not always object

### DIFF
--- a/src/Codeception/Lib/Connector/Laminas.php
+++ b/src/Codeception/Lib/Connector/Laminas.php
@@ -117,7 +117,7 @@ class Laminas extends AbstractBrowser
         return $this->laminasRequest;
     }
 
-    public function grabServiceFromContainer(string $service): object
+    public function grabServiceFromContainer(string $service): mixed
     {
         $serviceManager = $this->application->getServiceManager();
 


### PR DESCRIPTION
for example `$I->grabServiceFromContainer('Config')` will return array and without fix this would cause
```
[TypeError] Codeception\Lib\Connector\Laminas::grabServiceFromContainer(): Return value must be of type object, array returned
```